### PR TITLE
Feature/dockerize matchadb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
 FROM openjdk:14-jdk-alpine as builder
 
 # Set up the Working Directory
-WORKDIR /app
+WORKDIR /MatchaDB
 COPY . .
 
 # Get Gradle 6.6.1
 RUN apk add curl
 RUN curl -LJO https://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 RUN unzip gradle-6.6.1-bin.zip
-ENV GRADLE_HOME=/app/gradle-6.6.1
+ENV GRADLE_HOME=/MatchaDB/gradle-6.6.1
 ENV PATH=$GRADLE_HOME/bin:$PATH
 
 # Build the application
-RUN set -x && gradle build && ls -l /app/build/libs
+RUN set -x && gradle build && ls -l /MatchaDB/build/libs
 
 # Take the .war from the last build, and develop the container
 FROM openjdk:14-jdk-alpine
 WORKDIR /app
-COPY --from=builder /app/build/libs/MatchaDB-betav1.0.3-SNAPSHOT.war .
+COPY --from=builder /MatchaDB/build/libs/MatchaDB-betav1.0.3-SNAPSHOT.war .
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "--enable-preview", "-DdatabaseFile=/app/matchadb.json", "-DdatabaseName=\"MatchaDB\"", "MatchaDB-betav1.0.3-SNAPSHOT.war"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:14-jdk-alpine as builder
+
+# Set up the Working Directory
+WORKDIR /app
+COPY . .
+
+# Get Gradle 6.6.1
+RUN apk add curl
+RUN curl -LJO https://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+RUN unzip gradle-6.6.1-bin.zip
+ENV GRADLE_HOME=/app/gradle-6.6.1
+ENV PATH=$GRADLE_HOME/bin:$PATH
+
+# Build the application
+RUN set -x && gradle build && ls -l /app/build/libs
+
+# Take the .war from the last build, and develop the container
+FROM openjdk:14-jdk-alpine
+WORKDIR /app
+COPY --from=builder /app/build/libs/MatchaDB-betav1.0.3-SNAPSHOT.war .
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "--enable-preview", "-DdatabaseFile=/app/matchadb.json", "-DdatabaseName=\"MatchaDB\"", "MatchaDB-betav1.0.3-SNAPSHOT.war"]


### PR DESCRIPTION
<img width="1127" height="475" alt="image" src="https://github.com/user-attachments/assets/197be411-cf03-49ff-84b3-bd2f956349e3" />
I could successfully get a docker container for MatchaDB built and running in a Minikube pod on a node.